### PR TITLE
make it so that it will create all the intermediate-level directories…

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -17,7 +17,7 @@ javascript_folder = os.path.join(os.path.dirname(os.path.realpath(__file__)), "j
 
 if not os.path.exists(extentions_folder):
     print('Making the "web\extensions\FizzleDorf" folder')
-    os.mkdir(extentions_folder)
+    os.makedirs(extentions_folder)
 
 result = filecmp.dircmp(javascript_folder, extentions_folder)
 


### PR DESCRIPTION
make it so that it will create all the intermediate-level directories…, otherwise will fail import into custom_node

Error
```
Using xformers cross attention
module_name is ComfyUI_FizzNodes
Making the "web\extensions\FizzleDorf" folder
Traceback (most recent call last):
  File "/workspace/ComfyUI/ComfyUI-to-Python-Extension/../nodes.py", line 1735, in load_custom_node
    module_spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/workspace/ComfyUI/custom_nodes/ComfyUI_FizzNodes/__init__.py", line 20, in <module>
    os.mkdir(extentions_folder)
FileNotFoundError: [Errno 2] No such file or directory: '/workspace/ComfyUI/ComfyUI-to-Python-Extension/web/extensions/FizzleDorf'

Cannot import /workspace/ComfyUI/custom_nodes/ComfyUI_FizzNodes module for custom nodes: [Errno 2] No such file or directory: '/workspace/ComfyUI/ComfyUI-to-Python-Extension/web/extensions/FizzleDorf'
module_name is ComfyUI-Advanced-ControlNet
module_name is ComfyUI-VideoHelperSuite
```