### PR TITLE
fix(ScheduledNodes): correct SDXL batch prompt schedule node `num_latents` type -> `LATENTS`

### DIFF
--- a/ScheduledNodes.py
+++ b/ScheduledNodes.py
@@ -279,7 +279,7 @@ class BatchPromptScheduleEncodeSDXLLatentInput:
             "target_height": ("INT", {"default": 1024.0, "min": 0, "max": MAX_RESOLUTION}),
             "text_g": ("STRING", {"multiline": True, "default": "CLIP_G"}), "clip": ("CLIP", ),
             "text_l": ("STRING", {"multiline": True, "default": "CLIP_L"}), "clip": ("CLIP", ),
-            "num_latents": ("Latent", ),
+            "num_latents": ("LATENT", ),
             "print_output":("BOOLEAN", {"default": False}),},
             "optional": {"pre_text_G": ("STRING", {"multiline": False,}),# "forceInput": True}),
             "app_text_G": ("STRING", {"multiline": False,}),# "forceInput": True}),


### PR DESCRIPTION
Currently throws:

```
Prompt outputs failed validation
BatchPromptScheduleSDXLLatentInput:
    - Return type mismatch between linked nodes: num_latents, LATENT != Latent
```

due to what I suspect was a simple typo of `Latent` where `LATENT` should have been.

Was introduced in:
https://github.com/FizzleDorf/ComfyUI_FizzNodes/commit/097f50640ede11e71d8d321411f95adda3452552#diff-d9f32f88d03c68f3407dd4515e895275e234122aa3a2746e374d6df658772806R281
