### PR TITLE
Adding some nodes

### DIFF
--- a/FrameNodes.py
+++ b/FrameNodes.py
@@ -26,7 +26,7 @@ class StringConcatenate:
     RETURN_TYPES = ("STRING",)
     FUNCTION = "frame_concatenate_list"
 
-    CATEGORY = "FizzNodes/CustomNodes"
+    CATEGORY = "FizzNodes/FrameNodes"
 
     def frame_concatenate_list(self, text_a, text_b, frame_b, text_c=None, frame_c=None, text_d=None, frame_d=None, text_e=None, frame_e=None, text_f=None, frame_f=None, text_g=None, frame_g=None):
         
@@ -70,7 +70,7 @@ class InitNodeFrame:
     RETURN_TYPES = ("FIZZFRAME","CONDITIONING","CONDITIONING",)
     FUNCTION = "create_frame"
 
-    CATEGORY = "FizzNodes/CustomNodes"
+    CATEGORY = "FizzNodes/FrameNodes"
 
     def create_frame(self, frame, positive_text, negative_text=None, general_positive=None, general_negative=None, previous_frame=None, clip=None):
         new_frame = {
@@ -131,7 +131,7 @@ class NodeFrame:
     RETURN_TYPES = ("FIZZFRAME","CONDITIONING","CONDITIONING",)
     FUNCTION = "create_frame"
 
-    CATEGORY = "FizzNodes/CustomNodes"
+    CATEGORY = "FizzNodes/FrameNodes"
 
     def create_frame(self, frame, previous_frame, positive_text, negative_text=None):
         self.frames = previous_frame.frames
@@ -174,7 +174,7 @@ class FrameConcatenate:
     RETURN_TYPES = ("STRING",)
     FUNCTION = "frame_concatenate"
 
-    CATEGORY = "FizzNodes/CustomNodes"
+    CATEGORY = "FizzNodes/FrameNodes"
 
     def frame_concatenate(self, frame):
         text_list = ""

--- a/FrameNodes.py
+++ b/FrameNodes.py
@@ -1,0 +1,132 @@
+class StringConcatenate:
+    def __init__(self):
+        pass
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "text_a": ("STRING", {"forceInput": True}),
+                "text_b": ("STRING", {"forceInput": True}),
+                "frame_b": ("INT", {"default": 32, "min": 1})
+            },
+            "optional": {
+                "text_c": ("STRING", {"forceInput": True}),
+                "frame_c": ("INT", {"min": 2}),
+                "text_d": ("STRING", {"forceInput": True}),
+                "frame_d": ("INT", {"min": 3}),
+                "text_e": ("STRING", {"forceInput": True}),
+                "frame_e": ("INT", {"min": 4}),
+                "text_f": ("STRING", {"forceInput": True}),
+                "frame_f": ("INT", {"min": 5}),
+                "text_g": ("STRING", {"forceInput": True}),
+                "frame_g": ("INT", {"min": 6})
+            }
+        }
+    RETURN_TYPES = ("STRING",)
+    FUNCTION = "frame_concatenate_list"
+
+    CATEGORY = "FizzNodes/CustomNodes"
+
+    def frame_concatenate_list(self, text_a, text_b, frame_b, text_c=None, frame_c=None, text_d=None, frame_d=None, text_e=None, frame_e=None, text_f=None, frame_f=None, text_g=None, frame_g=None):
+        
+        text_list = f'"0": "{text_a}",\n'
+        text_list += f'"{frame_b}": "{text_b}",\n'
+        if frame_c and text_c:
+            text_list += f'"{frame_c}": "{text_c}",\n'
+        if frame_d and text_d:
+            text_list += f'"{frame_d}": "{text_d}",\n'
+        if frame_e and text_e:
+            text_list += f'"{frame_e}": "{text_e}",\n'
+        if frame_f and text_f:
+            text_list += f'"{frame_f}": "{text_f}",\n'
+        if frame_g and text_g:
+            text_list += f'"{frame_g}": "{text_g}",\n'
+    
+        text_list = text_list[:-2]
+
+        print(text_list)
+
+        return (text_list,)
+    
+class NodeFrame:
+
+    def __init__(self):
+        self.frames = {}
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "positive_text": ("STRING", {"multiline": True}),
+                "frame": ("INT", {"default": 0, "min": 0})
+            },
+            "optional": {
+                "negative_text": ("STRING", {"multiline": True}),
+                "general_negative": ("STRING", {"multiline": True}),
+                "general_positive": ("STRING", {"multiline": True}),
+                "previous_frame": ("FIZZFRAME", {"forceInput": True}),
+            }
+        }
+    RETURN_TYPES = ("FIZZFRAME","STRING", "STRING",)
+    FUNCTION = "create_frame"
+
+    CATEGORY = "FizzNodes/CustomNodes"
+
+    def create_frame(self, positive_text, frame, negative_text=None, general_negative=None, general_positive=None, previous_frame=None):
+        new_frame = {
+            "positive_text": positive_text,
+            "negative_text": negative_text
+        }
+
+        if previous_frame:
+            new_frame.general_positive = previous_frame.general_positive
+            new_frame.general_negative = previous_frame.general_negative
+
+        if general_positive:
+            new_frame.general_positive = general_positive
+        
+        if general_negative:
+            new_frame.general_negative = general_negative
+
+        self.frames[frame] = new_frame
+        new_positive_text = f"{positive_text}, {general_positive}"
+        new_negative_text = f"{negative_text}, {general_negative}"
+
+        return (self, new_positive_text, new_negative_text,)
+
+class FrameConcatenate:
+    def __init__(self):
+        pass
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "frame": ("FIZZFRAME", {"forceInput": True})
+            },
+        }
+    RETURN_TYPES = ("STRING",)
+    FUNCTION = "frame_concatenate"
+
+    CATEGORY = "FizzNodes/CustomNodes"
+
+    def frame_concatenate(self, frame):
+        text_list = ""
+        for frame_digit in frame.frames:
+            new_frame = frame.frames[frame_digit]
+            text_list += f'"{frame_digit}": "{new_frame["positive_text"]}'
+            if new_frame.get("general_positive"):
+                text_list += f', {new_frame["general_positive"]}'
+            if new_frame.get("negative_text") or new_frame.get("general_negative"):
+                text_list += f', --neg '
+                if new_frame.get("negative_text"):
+                    text_list += f', {new_frame["negative_text"]}'
+                if new_frame.get("general_negative"):
+                    text_list += f', {new_frame["general_negative"]}'
+            text_list += f'",\n'
+        text_list = text_list[:-2]
+
+        print(text_list)
+
+        return (text_list,)

--- a/FrameNodes.py
+++ b/FrameNodes.py
@@ -45,8 +45,6 @@ class StringConcatenate:
     
         text_list = text_list[:-2]
 
-        print(text_list)
-
         return (text_list,)
     
 class InitNodeFrame:
@@ -82,14 +80,12 @@ class InitNodeFrame:
 
         if previous_frame:
             prev_frame = previous_frame.thisFrame
-            print(f"Previous Frame Found {prev_frame['general_positive']}")
             new_frame["general_positive"] = prev_frame["general_positive"]
             new_frame["general_negative"] = prev_frame["general_negative"]
             new_frame["clip"] = prev_frame["clip"]
             self.frames = previous_frame.frames
 
         if general_positive:
-            print(f"General positive {general_positive}")
             new_frame["general_positive"] = general_positive
         
         if general_negative:
@@ -100,9 +96,6 @@ class InitNodeFrame:
 
         if clip:
             new_frame["clip"] = clip 
-
-        print(f"Positive Text: {new_positive_text}") 
-        print(f"Negative Text: {new_negative_text}") 
 
         pos_tokens = new_frame["clip"].tokenize(new_positive_text)        
         pos_cond, pos_pooled = new_frame["clip"].encode_from_tokens(pos_tokens, return_pooled=True)
@@ -198,7 +191,5 @@ class FrameConcatenate:
                     text_list += f', {new_frame["general_negative"]}'
             text_list += f'",\n'
         text_list = text_list[:-2]
-
-        print(text_list)
 
         return (text_list,)

--- a/__init__.py
+++ b/__init__.py
@@ -60,7 +60,7 @@ from .ScheduledNodes import (
     BatchValueScheduleLatentInput, BatchPromptScheduleEncodeSDXLLatentInput, BatchPromptScheduleLatentInput
     #, BatchPromptScheduleNodeFlowEnd #, BatchGLIGENSchedule
 )
-from .FrameNodes import FrameConcatenate, NodeFrame, StringConcatenate
+from .FrameNodes import FrameConcatenate, InitNodeFrame, NodeFrame, StringConcatenate
 
 NODE_CLASS_MAPPINGS = {
     "Lerp": Lerp,
@@ -90,6 +90,7 @@ NODE_CLASS_MAPPINGS = {
     #"BatchGLIGENSchedule": BatchGLIGENSchedule,
 
     "StringConcatenate":StringConcatenate,
+    "Init FizzFrame":InitNodeFrame,
     "FizzFrame":NodeFrame,
     "FizzFrameConcatenate":FrameConcatenate,
 }

--- a/__init__.py
+++ b/__init__.py
@@ -60,6 +60,7 @@ from .ScheduledNodes import (
     BatchValueScheduleLatentInput, BatchPromptScheduleEncodeSDXLLatentInput, BatchPromptScheduleLatentInput
     #, BatchPromptScheduleNodeFlowEnd #, BatchGLIGENSchedule
 )
+from .FrameNodes import FrameConcatenate, NodeFrame, StringConcatenate
 
 NODE_CLASS_MAPPINGS = {
     "Lerp": Lerp,
@@ -88,6 +89,9 @@ NODE_CLASS_MAPPINGS = {
     #"BatchPromptScheduleNodeFlowEnd":BatchPromptScheduleNodeFlowEnd,
     #"BatchGLIGENSchedule": BatchGLIGENSchedule,
 
+    "StringConcatenate":StringConcatenate,
+    "FizzFrame":NodeFrame,
+    "FizzFrameConcatenate":FrameConcatenate,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {


### PR DESCRIPTION
This pull requests add some nodes under FizzNodes/FrameNodes:

All this nodes are made to simplify the process to create the text under "BatchPromptSchedule".

* Init FizzFrame has as input:
   - Frame: an integer that denote in which frame this prompt should be applied
   - Positive text: positive text of the frame
   - Negative text: negative text of the frame
   - General positive: a positive text that can be used on all the prompt flow
   - General negative: a negative text that can be used on all the prompt flow
   - Clip: to insert if this fizz frame is the first one
   - Previous frame: to insert if this fizz frame is an intermediate one
* FizzFrame: like above one, but without "general positive", "general negative" and "clip".

If we need to override the "general positive", "general negative" or the "clip". It can be done by reusing the Init FizzFrame as an intermediate step.

Both of them have as output : "FizzFrame", "positive conditioning" and "negative conditioning". The last two can be used with a KSampler if we want to have a preview of the image or we want to use the image with Controlnet.

* FizzFrameConcatenate:  it takes the last FizzFrame as input and concanted all them to generate the string to serve to BatchPromptSchedule.

* StringConcatenate: it is a very simplified version of FizzFrameConcatenate that uses only strings and integer

I attach the following imagine that includes an example of worflow that can be used with the new nodes.

![AnimateDiff_00022_](https://github.com/FizzleDorf/ComfyUI_FizzNodes/assets/8471053/57abc066-0e44-4f4b-a0ed-c294dd959dc8)

And here the final result (without workflow)

![AnimateDiff_00022_](https://github.com/FizzleDorf/ComfyUI_FizzNodes/assets/8471053/d8848122-6f5b-4ce3-81d0-430f557229fc)

This pull requests is updated with the last commit on the moment of the creation of the request.
