### PR TITLE
add Image Batch from Value Schedule

### DIFF
--- a/ScheduledNodes.py
+++ b/ScheduledNodes.py
@@ -623,3 +623,24 @@ class BatchValueScheduleLatentInput:
         max_frames = num_elements
         t = batch_get_inbetweens(batch_parse_key_frames(text, max_frames), max_frames)
         return (t, list(map(int,t)), num_latents, )
+
+# Expects a Batch Value Schedule list input, it exports an image batch with images taken from an input image batch
+# Expects values to be in range -1...1, could be normalized to accept any value range
+class ImageBatchFromValueSchedule:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "images": ("IMAGE",),
+                "values": ("FLOAT", { "default": 1.0, "min": -1.0, "max": 1.0, "label": "values" }),
+            }
+        }
+
+    RETURN_TYPES = ("IMAGE",)
+    FUNCTION = "animate"
+    CATEGORY = "FizzNodes 📅🅕🅝/BatchScheduleNodes"
+
+    def animate(self, images, values):
+        n = images.shape[0] - 1
+        values = [values] * n if isinstance(values, float) else [round((v + 1) / 2 * n) for v in values]
+        return (images[values], )

--- a/__init__.py
+++ b/__init__.py
@@ -57,7 +57,8 @@ from .WaveNodes import Lerp, SinWave, InvSinWave, CosWave, InvCosWave, SquareWav
 from .ScheduledNodes import (
     ValueSchedule, PromptSchedule, PromptScheduleNodeFlow, PromptScheduleNodeFlowEnd, PromptScheduleEncodeSDXL,
     StringSchedule, BatchPromptSchedule, BatchValueSchedule, BatchPromptScheduleEncodeSDXL, BatchStringSchedule,
-    BatchValueScheduleLatentInput, BatchPromptScheduleEncodeSDXLLatentInput, BatchPromptScheduleLatentInput
+    BatchValueScheduleLatentInput, BatchPromptScheduleEncodeSDXLLatentInput, BatchPromptScheduleLatentInput,
+    ImageBatchFromValueSchedule
     #, BatchPromptScheduleNodeFlowEnd #, BatchGLIGENSchedule
 )
 from .FrameNodes import FrameConcatenate, InitNodeFrame, NodeFrame, StringConcatenate
@@ -87,6 +88,7 @@ NODE_CLASS_MAPPINGS = {
     "BatchValueScheduleLatentInput": BatchValueScheduleLatentInput,
     "BatchPromptScheduleSDXLLatentInput":BatchPromptScheduleEncodeSDXLLatentInput,
     "BatchPromptScheduleLatentInput":BatchPromptScheduleLatentInput,
+    "ImageBatchFromValueSchedule":ImageBatchFromValueSchedule,
     #"BatchPromptScheduleNodeFlowEnd":BatchPromptScheduleNodeFlowEnd,
     #"BatchGLIGENSchedule": BatchGLIGENSchedule,
 
@@ -128,10 +130,10 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "BatchValueScheduleLatentInput": "Batch Value Schedule (Latent Input) 📅🅕🅝",
     "BatchPromptScheduleSDXLLatentInput": "Batch Prompt Schedule SDXL (Latent Input) 📅🅕🅝",
     "BatchPromptScheduleLatentInput": "Batch Prompt Schedule (Latent Input) 📅🅕🅝",
+    "ImageBatchFromValueSchedule":"Image Batch From Value Schedule 📅🅕🅝",
     "ConcatStringSingle": "Concat String (Single) 📅🅕🅝",
     "convertKeyframeKeysToBatchKeys":"Keyframe Keys To Batch Keys 📅🅕🅝",
     "SelectFrameNumber":"Select Frame Number 📅🅕🅝",
     "CalculateFrameOffset":"Calculate Frame Offset 📅🅕🅝",
-
 }
 print('\033[34mFizzleDorf Custom Nodes: \033[92mLoaded\033[0m')


### PR DESCRIPTION
Create an image batch from a batch value schedule. Useful with values from https://www.framesync.xyz/

![image](https://github.com/FizzleDorf/ComfyUI_FizzNodes/assets/427614/d4ccc9b7-3712-4587-9314-fe06b686e7f4)

I have no use of a non-batch (frame-by-frame) variant, but can be easily done.