### PR TITLE
cutoff prompt when its too long for clip encode

### DIFF
--- a/BatchFuncs.py
+++ b/BatchFuncs.py
@@ -180,6 +180,11 @@ def BatchPoolAnimConditioning(cur_prompt_series, nxt_prompt_series, weight_serie
 
     for i in range(len(cur_prompt_series)):
         tokens = clip.tokenize(str(cur_prompt_series[i]))
+
+        if len(tokens['l']) > 1:
+            print(f"Warning: input prompt: \n{str(cur_prompt_series[i])}\n was too long and will be truncated!!")
+            tokens['l'] = [tokens['l'][0]]
+
         cond_to, pooled_to = clip.encode_from_tokens(tokens, return_pooled=True)
 
         if i < len(nxt_prompt_series):


### PR DESCRIPTION
When the input prompt is too long it results in two clip_encoded token vectors of len 77 instead of just one. This causes the `final_conditioning = torch.cat(cond_out, dim=0)` line to crash when other prompts only have one [77,768] token vector.

This pr simply detects when this happens and drops the second encoded part of the input prompt (this effectively ignores the end of the prompt that's too long).

This fixes [this bug](https://github.com/FizzleDorf/ComfyUI_FizzNodes/issues/60)