### PR TITLE
Fixing InitNodeFrame and NodeFrame outputs names

### DIFF
--- a/FrameNodes.py
+++ b/FrameNodes.py
@@ -95,6 +95,7 @@ class InitNodeFrame:
             }
         }
     RETURN_TYPES = ("FIZZFRAME","CONDITIONING","CONDITIONING",)
+    RETURN_NAMES = ("FIZZFRAME","POS_COND","NEG_COND",)
     FUNCTION = "create_frame"
 
     CATEGORY = "FizzNodes 📅🅕🅝/FrameNodes"
@@ -156,6 +157,7 @@ class NodeFrame:
             }
         }
     RETURN_TYPES = ("FIZZFRAME","CONDITIONING","CONDITIONING",)
+    RETURN_NAMES = ("FIZZFRAME","POS_COND","NEG_COND",)
     FUNCTION = "create_frame"
 
     CATEGORY = "FizzNodes 📅🅕🅝/FrameNodes"


### PR DESCRIPTION
I suggest to explicitly name the CONDITIONING outputs of NodeFrame and InitNodeFrame, because otherwise we have two outputs with the same name and it can be confusing.